### PR TITLE
added Google credential check if the token has been fetched yet

### DIFF
--- a/python/bmcversion.py
+++ b/python/bmcversion.py
@@ -45,8 +45,8 @@ credentials = impersonated_credentials.Credentials(
     lifetime=3600,
 )
 
-# Refresh the token if it has expired
-if credentials.expired:
+# Refresh the token if it has expired or fetch if missing
+if credentials.expired or credentials.token is None:
     credentials.refresh(Request())
 
 # Get the access token

--- a/python/countfailedjobs.py
+++ b/python/countfailedjobs.py
@@ -45,8 +45,8 @@ credentials = impersonated_credentials.Credentials(
     lifetime=3600,
 )
 
-# Refresh the token if it has expired
-if credentials.expired:
+# Refresh the token if it has expired or fetch if missing
+if credentials.expired or credentials.token is None:
     credentials.refresh(Request())
 
 # Get the access token


### PR DESCRIPTION
quick fix to hopefully help other future explorers.

I've been trying to make calls from GCP Cloud Run Functions and wondering why I was getting http401, the `credentials.token` is `None` by default and as we arent using [AuthorizedSession](https://github.com/googleapis/google-auth-library-python/blob/6a982be06e513a3182069cd910466e743fa7db6a/google/auth/transport/requests.py#L298) it doesn't automatically handle this.

The only check we seem to be missing that it does during [before_request](https://github.com/googleapis/google-auth-library-python/blob/6a982be06e513a3182069cd910466e743fa7db6a/google/auth/credentials.py#L210) is the null/none check in [property .valid](https://github.com/googleapis/google-auth-library-python/blob/6a982be06e513a3182069cd910466e743fa7db6a/google/auth/credentials.py#L103C16-L103C59).

maybe need to reconsider refactoring to calling [before_request](https://github.com/googleapis/google-auth-library-python/blob/6a982be06e513a3182069cd910466e743fa7db6a/google/auth/credentials.py#L210) or using [AuthorizedSession](https://github.com/googleapis/google-auth-library-python/blob/6a982be06e513a3182069cd910466e743fa7db6a/google/auth/transport/requests.py#L298) directly for future compatibility.